### PR TITLE
 move common code to libamp, expose web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__

--- a/ca_amp_ctrl.py
+++ b/ca_amp_ctrl.py
@@ -9,7 +9,7 @@ import libamp
 parser = argparse.ArgumentParser(description="Control Cambridge Audio amplifiers.")
 parser.add_argument('--pin', nargs='?', default=4, type=int)
 parser.add_argument('--repeat', nargs='?', default=1, type=libamp.posint)
-parser.add_argument('command', nargs=1, choices=amp.cmd.keys())
+parser.add_argument('command', nargs=1, choices=libamp.cmd.keys())
 args = parser.parse_args()
 
 command = args.command[0].lower()

--- a/ca_amp_ctrl.py
+++ b/ca_amp_ctrl.py
@@ -1,101 +1,15 @@
 #!/usr/bin/python3
 
-# Send RC5-encoded commands.
-# Confirmed working with:
-#   Cambridge Audio azur 540A v2
-
-
-#############
-# CONSTANTS #
-#############
-
-RC5_PER = 889 # half-bit period (microseconds)
-CA_RC5_SYS = 16
-
-# dictionary of possible commands, mapped to the code we need to send
-cmd = {
-        'aux': 4,
-        'cd': 5,
-        'tuner': 3,
-        'dvd': 1,
-        'av': 2,
-        'tapemon': 0,
-        'vol-': 17,
-        'vol+': 16,
-        'mute': 13,
-        'standby': 12,
-        'bright': 18,
-        'source+': 19,
-        'source-': 20,
-        'clipoff': 21,
-        'clipon': 22,
-        'muteon': 50,
-        'muteoff': 51,
-        'ampon': 14,
-        'ampoff': 15
-        }
-
-#############
-# Functions #
-#############
-
-# build RC5 message, return as int
-def build_rc5(sys, cmd):
-    RC5_START = 0b100 + (0b010 * (cmd<64))
-    RC5_SYS = int(sys)
-    RC5_CMD = int(cmd)
-
-    # RC-5 message has a 3-bit start sequence, a 5-bit system ID, and a 6-bit command.
-    RC5_MSG = ((RC5_START & 0b111) << 11) | ((RC5_SYS & 0b11111) << 6) | (RC5_CMD & 0b111111)
-    
-    return RC5_MSG
-
-# manchester encode waveform. Period is the half-bit period in microseconds.
-def wave_mnch(DATA, PIN, PERIOD):
-    pi.set_mode(PIN, pigpio.OUTPUT) # set GPIO pin to output.
-
-    # create msg
-    # syntax: pigpio.pulse(gpio_on, gpio_off, delay us)
-    msg = []
-    for i in bin(DATA)[2:]: # this is a terrible way to iterate over bits... but it works.
-        if i=='1':
-            msg.append(pigpio.pulse(0,1<<PIN,PERIOD)) # L
-            msg.append(pigpio.pulse(1<<PIN,0,PERIOD)) # H
-        else:
-            msg.append(pigpio.pulse(1<<PIN,0,PERIOD)) # H
-            msg.append(pigpio.pulse(0,1<<PIN,PERIOD)) # L
-
-    msg.append(pigpio.pulse(0,1<<PIN,PERIOD)) # return line to idle condition.
-    pi.wave_add_generic(msg)
-    wid = pi.wave_create()
-    return wid
-
-# check for positive integer
-def posint(n):
-    try:
-        if int(n)>0:
-            return int(n)
-        else:
-            raise ValueError
-    except ValueError:
-            msg = str(n) + " is not a positive integer"
-            raise argparse.ArgumentTypeError(msg)
-
-##############
-# Start here #
-##############
-
-import pigpio
 import sys
 import argparse
+import libamp
 
-pi = pigpio.pi()
 
 # Build argument parser
 parser = argparse.ArgumentParser(description="Control Cambridge Audio amplifiers.")
 parser.add_argument('--pin', nargs='?', default=4, type=int)
-parser.add_argument('--repeat', nargs='?', default=1, type=posint)
-parser.add_argument('command', nargs=1, choices=cmd.keys())
+parser.add_argument('--repeat', nargs='?', default=1, type=libamp.posint)
+parser.add_argument('command', nargs=1, choices=amp.cmd.keys())
 args = parser.parse_args()
 
 command = args.command[0].lower()
@@ -104,12 +18,6 @@ print("Sending '" + command + "' command to pin " + str(args.pin))
 if args.repeat != 1:
     print(str(args.repeat) + " times")
 
-# generate RC5 message (int)
-rc5_msg = build_rc5(CA_RC5_SYS, cmd[command])
-# generate digital manchester-encoded waveform
-wid = wave_mnch(rc5_msg, args.pin, RC5_PER)
-
-for i in range(args.repeat):
-    cbs = pi.wave_send_once(wid)
+libamp.execute(args.pin, command, args.repeat)
 
 sys.exit(0)

--- a/libamp.py
+++ b/libamp.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python3
+
+# Send RC5-encoded commands.
+# Confirmed working with:
+#   Cambridge Audio azur 540A v2
+
+import pigpio
+
+pi = pigpio.pi()
+
+
+#############
+# CONSTANTS #
+#############
+
+RC5_PER = 889 # half-bit period (microseconds)
+CA_RC5_SYS = 16
+
+# dictionary of possible commands, mapped to the code we need to send
+cmd = {
+        'aux': 4,
+        'cd': 5,
+        'tuner': 3,
+        'dvd': 1,
+        'av': 2,
+        'tapemon': 0,
+        'vol-': 17,
+        'vol+': 16,
+        'volup': 17,
+        'voldown': 16,
+        'mute': 13,
+        'standby': 12,
+        'bright': 18,
+        'source+': 19,
+        'source-': 20,
+        'sourcenext': 19,
+        'sourceprev': 20,
+        'clipoff': 21,
+        'clipon': 22,
+        'muteon': 50,
+        'muteoff': 51,
+        'ampon': 14,
+        'ampoff': 15
+        }
+
+#############
+# Functions #
+#############
+
+# build RC5 message, return as int
+def build_rc5(cmd):
+    RC5_START = 0b100 + (0b010 * (cmd<64))
+    RC5_SYS = int(CA_RC5_SYS)
+    RC5_CMD = int(cmd)
+
+    # RC-5 message has a 3-bit start sequence, a 5-bit system ID, and a 6-bit command.
+    RC5_MSG = ((RC5_START & 0b111) << 11) | ((RC5_SYS & 0b11111) << 6) | (RC5_CMD & 0b111111)
+    
+    return RC5_MSG
+
+# manchester encode waveform. Period is the half-bit period in microseconds.
+def wave_mnch(DATA, PIN):
+    pi.set_mode(PIN, pigpio.OUTPUT) # set GPIO pin to output.
+
+    # create msg
+    # syntax: pigpio.pulse(gpio_on, gpio_off, delay us)
+    msg = []
+    for i in bin(DATA)[2:]: # this is a terrible way to iterate over bits... but it works.
+        if i=='1':
+            msg.append(pigpio.pulse(0,1<<PIN,RC5_PER)) # L
+            msg.append(pigpio.pulse(1<<PIN,0,RC5_PER)) # H
+        else:
+            msg.append(pigpio.pulse(1<<PIN,0,RC5_PER)) # H
+            msg.append(pigpio.pulse(0,1<<PIN,RC5_PER)) # L
+
+    msg.append(pigpio.pulse(0,1<<PIN,RC5_PER)) # return line to idle condition.
+    pi.wave_add_generic(msg)
+    wid = pi.wave_create()
+    return wid
+
+# check for positive integer
+def posint(n):
+    try:
+        if int(n)>0:
+            return int(n)
+        else:
+            raise ValueError
+    except ValueError:
+            msg = str(n) + " is not a positive integer"
+            raise argparse.ArgumentTypeError(msg)
+
+def execute(pin, command, repeat):
+
+    # generate RC5 message (int)
+    rc5_msg = build_rc5(cmd[command])
+
+    # generate digital manchester-encoded waveform
+    wid = wave_mnch(rc5_msg, pin)
+
+    for i in range(repeat):
+        cbs = pi.wave_send_once(wid)
+    

--- a/web.py
+++ b/web.py
@@ -1,0 +1,48 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import libamp
+import argparse
+from urllib.parse import urlparse, parse_qsl
+from functools import partial
+
+class Server(BaseHTTPRequestHandler):
+
+  def __init__(self, pin, *args, **kwargs):
+        self.pin = pin
+        super().__init__(*args, **kwargs)
+
+  def do_GET(self):
+
+    qs = dict(parse_qsl(urlparse(self.path).query))
+    command = qs["cmd"]
+    repeat = 1
+    if "repeat" in qs:
+      repeat = qs["repeat"]
+
+    try:
+      libamp.execute(self.pin, command, repeat)
+      self.send_response(200)
+      self.end_headers()
+      self.wfile.write(bytes("OK", "utf-8"))
+    except Exception as err:
+      self.send_response(500)
+      self.end_headers()
+      self.wfile.write(bytes("Error: {0}".format(err), "utf-8"))
+        
+def run(port, pin):
+    server_address = ("", port)
+    handler = partial(Server, pin)
+    httpd = HTTPServer(server_address, handler)
+    
+    print("Starting Cambridge Audio amplifier web control on port %d..." % port)
+    httpd.serve_forever()
+
+
+parser = argparse.ArgumentParser(description="Web server for Cambridge Audio amplifiers control")
+parser.add_argument("--pin", nargs="?", default=4, type=int)
+parser.add_argument("--port", nargs="?", default=9696, type=int)
+args = parser.parse_args()
+
+run(port=args.port, pin=args.pin)
+        
+
+


### PR DESCRIPTION
I want to control my receiver from openHAB which is running on different machine than the one that controls my receiver. I need some kind of remote interface to be able to do that - so I added a simple http interface to do that.

- moved amplifier control code into libamp.py
- added web.py which is a simple web request handler
- added aliases for `vol+, vol-, source+, source-` to avoid url encoding in requests

So you can now launch web server via web.py , e,g `python3 web.py --port 8080 --pin 4` and then do requests like: `curl localhost:8080?cmd=ampoff` `curl localhost:8080?cmd=volup&repeat=5`

Does it sound reasonable?
