### PR TITLE
Add codes for different amplifier models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# pi_hifi_ctrl
+# pi\_hifi\_ctrl
 # Raspberry Pi Hi-Fi Amplifier Control
 
 This project aims to breathe new life into old Hi-Fi amplifiers/receivers, by adding network (or automatic) control via a Raspberry Pi.
 
 ## Supported Amplifiers:
 
-* Cambridge Audio azur 540A/640A v2, 840A v2
+* Cambridge Audio azur 540A/640A v2, 840A v2, CXA81
 
 If you have another Cambridge Audio amplifier, please contact me, I'll do my best to find the relevant documentation and add support for it.
 
@@ -20,13 +20,14 @@ If you have another Cambridge Audio amplifier, please contact me, I'll do my bes
 * Connect your pin to the signal wire of an RCA cable, and a ground to the shield.
 * Plug the RCA cable in to the "Ctrl In" socket on your Cambridge Audio amplifier.
 
-## ca_amp_ctrl.py Usage:
+## ca\_amp\_ctrl.py Usage:
 
-ca_amp_ctrl.py is used to send a command to the amplifier.
+`ca_amp_ctrl.py` is used to send a command to the amplifier.
 
-    ca_amp_ctrl.py [-h] [--pin [GPIO number]] [--repeat [positive integer]] command
+    ca_amp_ctrl.py [-h] [--pin [GPIO number]] [--repeat [positive integer]] [--model [model number]] command
 
-Exactly one command must be specified.
+Exactly one command must be specified. 
+Commands differ between amplifier models, for the 540A/640A they are:
 
 | Command        | Function     | 
 | ------------- |-------------| 
@@ -42,15 +43,18 @@ Exactly one command must be specified.
 
 The other optional arguments are:
 
-**-h** merely shows brief usage help  
+**-h** merely shows brief usage help (including a full list of available commands and amplifier models)  
 **--pin [GPIO number]** to specify the GPIO pin to transmit on (default: 4)  
 **--repeat [positive integer]** to repeat the command (e.g. vol+/vol- only move the volume a very small amount)  
+**--model [model number]** to select your amplifier model, available choices are: CXA81, 840A, or 540A.
+The default is 540A, which should also be compatible with the 640A.  
 
-## cec_stream.py Usage:
+## cec\_stream.py Usage:
 
-cec_stream.py is used to receive commands from a TV via HDMI and forward them on to the amplifier. The amplifier will turn on & off when the TV does, and will respond to the TV's volume & mute buttons.
+`cec_stream.py` is used to receive commands from a TV via HDMI and forward them on to the amplifier.
+The amplifier will turn on & off when the TV does, and will respond to the TV's volume & mute buttons.
 
-Copy cec_stream.py into /home/pi/cec/ and startup_cec in /etc/init.d/ , then run:
+Copy `cec_stream.py` into `/home/pi/cec/` and `startup_cec` into `/etc/init.d/`, then run:
 
     sudo update-rc.d startup_cec defaults
 

--- a/ca_amp_ctrl.py
+++ b/ca_amp_ctrl.py
@@ -5,11 +5,22 @@ import argparse
 import libamp
 
 
+all_models = {model for model in libamp.command_table}
+all_commands = {
+    command for model in all_models for command in libamp.command_table[model]
+}
+
 # Build argument parser
 parser = argparse.ArgumentParser(description="Control Cambridge Audio amplifiers.")
-parser.add_argument('--pin', nargs='?', default=4, type=int)
-parser.add_argument('--repeat', nargs='?', default=1, type=libamp.posint)
-parser.add_argument('command', nargs=1, choices=libamp.cmd.keys())
+parser.add_argument("--pin", nargs="?", default=4, type=int)
+parser.add_argument("--repeat", nargs="?", default=1, type=libamp.posint)
+parser.add_argument("--model", default="540A", choices=libamp.all_models)
+parser.add_argument(
+    "command",
+    nargs=1,
+    choices=libamp.all_commands,
+    help="Not all commands are available for all models!",
+)
 args = parser.parse_args()
 
 command = args.command[0].lower()
@@ -18,6 +29,6 @@ print("Sending '" + command + "' command to pin " + str(args.pin))
 if args.repeat != 1:
     print(str(args.repeat) + " times")
 
-libamp.execute(args.pin, command, args.repeat)
+libamp.execute(args.pin, command, args.repeat, model=args.model)
 
 sys.exit(0)

--- a/cec_stream.py
+++ b/cec_stream.py
@@ -10,38 +10,38 @@
 #############
 VOL_UP = "key pressed: volume up (41)"
 VOL_DN = "key pressed: volume down (42)"
-MUTE   = "key pressed: mute (43)"
-READY  = "audio status '7f'" # message sent by cec-client to TV at end of handshaking
+MUTE = "key pressed: mute (43)"
+READY = "audio status '7f'"  # message sent by cec-client to TV at end of handshaking
 
 VOL_STEPS = 4
 
-PIN = 4 # CPU GPIO number (not physical IO header pin number)
+PIN = 4  # CPU GPIO number (not physical IO header pin number)
 
-RC5_PER = 889 # half-bit period (microseconds)
+RC5_PER = 889  # half-bit period (microseconds)
 CA_RC5_SYS = 16
 
 # dictionary of possible commands, mapped to the code we need to send
 cmd = {
-        'aux': 4,
-        'cd': 5,
-        'tuner': 3,
-        'dvd': 1,
-        'av': 2,
-        'tapemon': 0,
-        'vol-': 17,
-        'vol+': 16,
-        'mute': 13,
-        'standby': 12,
-        'bright': 18,
-        'source+': 19,
-        'source-': 20,
-        'clipoff': 21,
-        'clipon': 22,
-        'muteon': 50,
-        'muteoff': 51,
-        'ampon': 14,
-        'ampoff': 15,
-        }
+    "aux": 4,
+    "cd": 5,
+    "tuner": 3,
+    "dvd": 1,
+    "av": 2,
+    "tapemon": 0,
+    "vol-": 17,
+    "vol+": 16,
+    "mute": 13,
+    "standby": 12,
+    "bright": 18,
+    "source+": 19,
+    "source-": 20,
+    "clipoff": 21,
+    "clipon": 22,
+    "muteon": 50,
+    "muteoff": 51,
+    "ampon": 14,
+    "ampoff": 15,
+}
 
 #############
 # Functions #
@@ -49,34 +49,40 @@ cmd = {
 
 # build RC5 message, return as int
 def build_rc5(sys, cmd):
-    RC5_START = 0b100 + (0b010 * (cmd<64))
+    RC5_START = 0b100 + (0b010 * (cmd < 64))
     RC5_SYS = int(sys)
     RC5_CMD = int(cmd)
 
     # RC-5 message has a 3-bit start sequence, a 5-bit system ID, and a 6-bit command.
-    RC5_MSG = ((RC5_START & 0b111) << 11) | ((RC5_SYS & 0b11111) << 6) | (RC5_CMD & 0b111111)
-    
+    RC5_MSG = (
+        ((RC5_START & 0b111) << 11) | ((RC5_SYS & 0b11111) << 6) | (RC5_CMD & 0b111111)
+    )
+
     return RC5_MSG
+
 
 # manchester encode waveform. Period is the half-bit period in microseconds.
 def wave_mnch(DATA, PIN, PERIOD):
-    pi.set_mode(PIN, pigpio.OUTPUT) # set GPIO pin to output.
+    pi.set_mode(PIN, pigpio.OUTPUT)  # set GPIO pin to output.
 
     # create msg
     # syntax: pigpio.pulse(gpio_on, gpio_off, delay us)
     msg = []
-    for i in bin(DATA)[2:]: # this is a terrible way to iterate over bits... but it works.
-        if i=='1':
-            msg.append(pigpio.pulse(0,1<<PIN,PERIOD)) # L
-            msg.append(pigpio.pulse(1<<PIN,0,PERIOD)) # H
+    for i in bin(DATA)[
+        2:
+    ]:  # this is a terrible way to iterate over bits... but it works.
+        if i == "1":
+            msg.append(pigpio.pulse(0, 1 << PIN, PERIOD))  # L
+            msg.append(pigpio.pulse(1 << PIN, 0, PERIOD))  # H
         else:
-            msg.append(pigpio.pulse(1<<PIN,0,PERIOD)) # H
-            msg.append(pigpio.pulse(0,1<<PIN,PERIOD)) # L
+            msg.append(pigpio.pulse(1 << PIN, 0, PERIOD))  # H
+            msg.append(pigpio.pulse(0, 1 << PIN, PERIOD))  # L
 
-    msg.append(pigpio.pulse(0,1<<PIN,PERIOD)) # return line to idle condition.
+    msg.append(pigpio.pulse(0, 1 << PIN, PERIOD))  # return line to idle condition.
     pi.wave_add_generic(msg)
     wid = pi.wave_create()
     return wid
+
 
 ##############
 # Start here #
@@ -91,19 +97,21 @@ pi = pigpio.pi()
 
 
 # generate RC5 message (int)
-rc5_msg_up = build_rc5(CA_RC5_SYS, cmd['vol+'])
-rc5_msg_dn = build_rc5(CA_RC5_SYS, cmd['vol-'])
+rc5_msg_up = build_rc5(CA_RC5_SYS, cmd["vol+"])
+rc5_msg_dn = build_rc5(CA_RC5_SYS, cmd["vol-"])
 # generate digital manchester-encoded waveform
 wid_up = wave_mnch(rc5_msg_up, PIN, RC5_PER)
 wid_dn = wave_mnch(rc5_msg_dn, PIN, RC5_PER)
 
 
-# run cec-client and watch output 
+# run cec-client and watch output
 # (because I can't get the damn python API to work!)
-p = subprocess.Popen(args = ['/usr/bin/cec-client', '--type',  'a', 'RPI'],
-        stdin =  subprocess.PIPE,
-        stdout = subprocess.PIPE,
-        universal_newlines = True)
+p = subprocess.Popen(
+    args=["/usr/bin/cec-client", "--type", "a", "RPI"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    universal_newlines=True,
+)
 
 
 while p.poll() is None:
@@ -112,34 +120,40 @@ while p.poll() is None:
     if "TV (0): power status changed" in l:
         power = l.split()[-1]
         if power == "'on'":
-            cbs = pi.wave_send_once(wave_mnch(build_rc5(CA_RC5_SYS,cmd['ampon']),PIN,RC5_PER))
+            cbs = pi.wave_send_once(
+                wave_mnch(build_rc5(CA_RC5_SYS, cmd["ampon"]), PIN, RC5_PER)
+            )
             print("Amp on")
-            p.stdin.write("tx 50:72:01 \n") # tell TV "Audio System Active" (i.e. turn off TV speakers)
+            p.stdin.write(
+                "tx 50:72:01 \n"
+            )  # tell TV "Audio System Active" (i.e. turn off TV speakers)
             p.stdin.flush()
         elif power == "'standby'":
-            cbs = pi.wave_send_once(wave_mnch(build_rc5(CA_RC5_SYS,cmd['ampoff']),PIN,RC5_PER))
+            cbs = pi.wave_send_once(
+                wave_mnch(build_rc5(CA_RC5_SYS, cmd["ampoff"]), PIN, RC5_PER)
+            )
             print("Amp off")
     elif READY in l:
-        p.stdin.write("tx 50:7a:08 \n") # report vol level 08
-        p.stdin.flush()                 # (TV won't reduce volume if it thinks it's at zero)
+        p.stdin.write("tx 50:7a:08 \n")  # report vol level 08
+        p.stdin.flush()  # (TV won't reduce volume if it thinks it's at zero)
     elif VOL_UP in l:
         print("Volume up")
-        p.stdin.write("tx 50:7a:10 \n") # report vol level 16
+        p.stdin.write("tx 50:7a:10 \n")  # report vol level 16
         p.stdin.flush()
         for i in range(VOL_STEPS):
             cbs = pi.wave_send_once(wid_up)
             time.sleep(0.05)
     elif VOL_DN in l:
         print("Volume down")
-        p.stdin.write("tx 50:7a:04 \n") # report vol level 04
+        p.stdin.write("tx 50:7a:04 \n")  # report vol level 04
         p.stdin.flush()
         for i in range(VOL_STEPS):
             cbs = pi.wave_send_once(wid_dn)
             time.sleep(0.05)
     elif MUTE in l:
-        cbs = pi.wave_send_once(wave_mnch(build_rc5(CA_RC5_SYS,cmd['mute']),PIN,RC5_PER))
+        cbs = pi.wave_send_once(
+            wave_mnch(build_rc5(CA_RC5_SYS, cmd["mute"]), PIN, RC5_PER)
+        )
 
 
 sys.exit(0)
-
-

--- a/libamp.py
+++ b/libamp.py
@@ -1,8 +1,9 @@
-#!/usr/bin/python3
+"""
+Send RC5-encoded commands to suit Cambridge Audio amplifiers.
 
-# Send RC5-encoded commands.
-# Confirmed working with:
-#   Cambridge Audio azur 540A v2
+Confirmed working with:
+  Cambridge Audio azur 540A v2
+"""
 
 import pigpio
 
@@ -13,90 +14,136 @@ pi = pigpio.pi()
 # CONSTANTS #
 #############
 
-RC5_PER = 889 # half-bit period (microseconds)
+RC5_PER = 889  # half-bit period (microseconds)
 CA_RC5_SYS = 16
 
-# dictionary of possible commands, mapped to the code we need to send
-cmd = {
-        'aux': 4,
-        'cd': 5,
-        'tuner': 3,
-        'dvd': 1,
-        'av': 2,
-        'tapemon': 0,
-        'vol-': 17,
-        'vol+': 16,
-        'volup': 17,
-        'voldown': 16,
-        'mute': 13,
-        'standby': 12,
-        'bright': 18,
-        'source+': 19,
-        'source-': 20,
-        'sourcenext': 19,
-        'sourceprev': 20,
-        'clipoff': 21,
-        'clipon': 22,
-        'muteon': 50,
-        'muteoff': 51,
-        'ampon': 14,
-        'ampoff': 15
-        }
+# dictionary of supported models, each containing:
+#   a dictionary of possible commands, mapped to the code we need to send
+command_table = {
+    "540A": {
+        "aux": 4,
+        "cd": 5,
+        "tuner": 3,
+        "dvd": 1,
+        "av": 2,
+        "tapemon": 0,
+        "vol-": 17,
+        "voldown": 17,
+        "vol+": 16,
+        "volup": 16,
+        "mute": 13,
+        "standby": 12,
+        "bright": 18,
+        "source+": 19,
+        "source-": 20,
+        "sourcenext": 19,
+        "sourceprev": 20,
+        "clipoff": 21,
+        "clipon": 22,
+        "muteon": 50,
+        "muteoff": 51,
+        "ampon": 14,
+        "ampoff": 15,
+    },
+    "840A": {
+        "source1": 4,
+        "source2": 5,
+        "source3": 3,
+        "source4": 1,
+        "source5": 2,
+        "source6": 0,
+        "source7": 6,
+        "source8": 7,
+        "tapemon": 7,
+        "vol-": 17,
+        "vol+": 16,
+        "volup": 17,
+        "voldown": 16,
+        "mute": 13,
+        "bright": 18,
+        "source+": 8,
+        "source-": 9,
+        "sourcenext": 8,
+        "sourceprev": 9,
+        "muteon": 50,
+        "muteoff": 51,
+        "ampon": 14,
+        "ampoff": 15,
+        "spkselect": 20,
+        "clipoff": 21,  # enters Balance mode
+    },
+    "CXA81": {"volup": 17, "voldown": 16, "ampon": 110, "ampoff": 111},
+}
+
+all_models = {model for model in command_table}
+all_commands = {
+    command for model in all_models for command in command_table[model]
+}
 
 #############
 # Functions #
 #############
 
-# build RC5 message, return as int
-def build_rc5(cmd):
-    RC5_START = 0b100 + (0b010 * (cmd<64))
+
+def build_rc5(cmd: int) -> int:
+    """Build an RC5 message"""
+    RC5_START = 0b100 + (0b010 * (cmd < 64))
     RC5_SYS = int(CA_RC5_SYS)
     RC5_CMD = int(cmd)
 
     # RC-5 message has a 3-bit start sequence, a 5-bit system ID, and a 6-bit command.
-    RC5_MSG = ((RC5_START & 0b111) << 11) | ((RC5_SYS & 0b11111) << 6) | (RC5_CMD & 0b111111)
-    
+    RC5_MSG = (
+        ((RC5_START & 0b111) << 11) | ((RC5_SYS & 0b11111) << 6) | (RC5_CMD & 0b111111)
+    )
+
     return RC5_MSG
 
-# manchester encode waveform. Period is the half-bit period in microseconds.
-def wave_mnch(DATA, PIN):
-    pi.set_mode(PIN, pigpio.OUTPUT) # set GPIO pin to output.
+
+def wave_mnch(DATA: int, PIN: int):
+    """
+    manchester encode waveform. Period is the half-bit period in microseconds.
+    """
+    pi.set_mode(PIN, pigpio.OUTPUT)  # set GPIO pin to output.
 
     # create msg
     # syntax: pigpio.pulse(gpio_on, gpio_off, delay us)
     msg = []
-    for i in bin(DATA)[2:]: # this is a terrible way to iterate over bits... but it works.
-        if i=='1':
-            msg.append(pigpio.pulse(0,1<<PIN,RC5_PER)) # L
-            msg.append(pigpio.pulse(1<<PIN,0,RC5_PER)) # H
-        else:
-            msg.append(pigpio.pulse(1<<PIN,0,RC5_PER)) # H
-            msg.append(pigpio.pulse(0,1<<PIN,RC5_PER)) # L
 
-    msg.append(pigpio.pulse(0,1<<PIN,RC5_PER)) # return line to idle condition.
+    # this is a terrible way to iterate over bits... but it works.
+    for i in bin(DATA)[2:]:
+        if i == "1":
+            msg.append(pigpio.pulse(0, 1 << PIN, RC5_PER))  # L
+            msg.append(pigpio.pulse(1 << PIN, 0, RC5_PER))  # H
+        else:
+            msg.append(pigpio.pulse(1 << PIN, 0, RC5_PER))  # H
+            msg.append(pigpio.pulse(0, 1 << PIN, RC5_PER))  # L
+
+    msg.append(pigpio.pulse(0, 1 << PIN, RC5_PER))  # return line to idle condition.
     pi.wave_add_generic(msg)
     wid = pi.wave_create()
     return wid
 
-# check for positive integer
+
 def posint(n):
+    """check for positive integer"""
     try:
-        if int(n)>0:
+        if int(n) > 0:
             return int(n)
         else:
             raise ValueError
     except ValueError:
-            msg = str(n) + " is not a positive integer"
-            raise argparse.ArgumentTypeError(msg)
+        msg = str(n) + " is not a positive integer"
+        raise argparse.ArgumentTypeError(msg)
 
-def execute(pin, command, repeat):
+
+def execute(pin: int, command: str, repeat: int, model: str = "504A"):
+    """execute a given command"""
 
     # generate RC5 message (int)
-    rc5_msg = build_rc5(cmd[command])
+    rc5_msg = build_rc5(command_table[model][command])
 
     # generate digital manchester-encoded waveform
     wid = wave_mnch(rc5_msg, pin)
 
     for i in range(repeat):
         cbs = pi.wave_send_once(wid)
-    

--- a/web.py
+++ b/web.py
@@ -4,45 +4,47 @@ import argparse
 from urllib.parse import urlparse, parse_qsl
 from functools import partial
 
-class Server(BaseHTTPRequestHandler):
 
-  def __init__(self, pin, *args, **kwargs):
+class Server(BaseHTTPRequestHandler):
+    def __init__(self, pin, model, *args, **kwargs):
         self.pin = pin
+        self.model = model
         super().__init__(*args, **kwargs)
 
-  def do_GET(self):
+    def do_GET(self):
 
-    qs = dict(parse_qsl(urlparse(self.path).query))
-    command = qs["cmd"]
-    repeat = 1
-    if "repeat" in qs:
-      repeat = qs["repeat"]
+        qs = dict(parse_qsl(urlparse(self.path).query))
+        command = qs["cmd"]
+        repeat = 1
+        if "repeat" in qs:
+            repeat = qs["repeat"]
 
-    try:
-      libamp.execute(self.pin, command, repeat)
-      self.send_response(200)
-      self.end_headers()
-      self.wfile.write(bytes("OK", "utf-8"))
-    except Exception as err:
-      self.send_response(500)
-      self.end_headers()
-      self.wfile.write(bytes("Error: {0}".format(err), "utf-8"))
-        
-def run(port, pin):
+        try:
+            libamp.execute(self.pin, command, repeat, model=self.model)
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(bytes("OK", "utf-8"))
+        except Exception as err:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(bytes("Error: {0}".format(err), "utf-8"))
+
+
+def run(port, pin, model):
     server_address = ("", port)
-    handler = partial(Server, pin)
+    handler = partial(Server, pin, model)
     httpd = HTTPServer(server_address, handler)
-    
-    print("Starting Cambridge Audio amplifier web control on port %d..." % port)
+
+    print("Starting Cambridge Audio %s amplifier web control on port %d..." % (model, port))
     httpd.serve_forever()
 
 
-parser = argparse.ArgumentParser(description="Web server for Cambridge Audio amplifiers control")
+parser = argparse.ArgumentParser(
+    description="Web server for Cambridge Audio amplifiers control"
+)
 parser.add_argument("--pin", nargs="?", default=4, type=int)
 parser.add_argument("--port", nargs="?", default=9696, type=int)
+parser.add_argument("--model", default="540A", choices=libamp.all_models)
 args = parser.parse_args()
 
-run(port=args.port, pin=args.pin)
-        
-
-
+run(port=args.port, pin=args.pin, model=args.model)


### PR DESCRIPTION
New command line argument --models used to select between: 540A (default), 840A, or CXA81

Thanks to @kovaga for the 840A codes and @Halmoni100 for the CXA81